### PR TITLE
Update ERDDAP servers on push to main/development

### DIFF
--- a/.github/workflows/update-erddap-servers.yaml
+++ b/.github/workflows/update-erddap-servers.yaml
@@ -32,4 +32,4 @@ jobs:
           passphrase: ${{ secrets.PROD_SERVER_PASSPHRASE }}
           key: ${{ secrets.PROD_SERVER_SSH_KEY }}
           fingerprint: ${{ secrets.PROD_SERVER_FINGERPRINT }}
-          script: cd  ~/cioos-pacific-erddap/; sh update-erddap.sh
+          script: cd  ~/cioos-pacific-erddap/; sh update-erddap.sh --hardFlag

--- a/.github/workflows/update-erddap-servers.yaml
+++ b/.github/workflows/update-erddap-servers.yaml
@@ -1,0 +1,35 @@
+name: Update ERDDAP server
+on:
+  push:
+    branches:
+      - main
+      - development
+
+jobs:
+  update:
+    name: Update ERDDAP
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Update development server
+        if: ${{github.ref_name}} == 'development'
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEV_SERVER_HOST }}
+          username: ${{ secrets.DEV_SERVER_USERNAME }}
+          passphrase: ${{ secrets.DEV_SERVER_PASSPHRASE }}
+          key: ${{ secrets.DEV_SERVER_SSH_KEY }}
+          fingerprint: ${{ secrets.DEV_SERVER_FINGERPRINT }}
+          script: cd  ~/cioos-pacific-erddap/; sh update-erddap.sh --hardFlag
+
+      - name: Update production server
+        if: ${{github.ref_name}} == 'main'
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PROD_SERVER_HOST }}
+          username: ${{ secrets.PROD_SERVER_USERNAME }}
+          passphrase: ${{ secrets.PROD_SERVER_PASSPHRASE }}
+          key: ${{ secrets.PROD_SERVER_SSH_KEY }}
+          fingerprint: ${{ secrets.PROD_SERVER_FINGERPRINT }}
+          script: cd  ~/cioos-pacific-erddap/; sh update-erddap.sh


### PR DESCRIPTION


This PR adds a new workflow that is triggered on pushes to main/development.

This will then connect to the respective servers via SSH and run the update-erddap.sh script.

The SSH informations should be stored as  secrets for each servers respectively as:

- {PROD/DEV}_SERVER_HOST 
- {PROD/DEV}_SERVER_USERNAME
- {PROD/DEV}_SERVER_PASSPHRASE 
- {PROD/DEV}_SERVER_SSH_KEY
- {PROD/DEV}_SERVER_FINGERPRINT 
