### PR TITLE
changed admin institutuion to https://cioospacific.ca/ since server w…

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -20,7 +20,7 @@ ERDDAP_emailProperties=mail.smtp.starttls.enable|true
 
 # Information about the ERDDAP administrator
 ERDDAP_adminInstitution=Institution
-ERDDAP_adminInstitutionUrl=www.instituteion-url.com
+ERDDAP_adminInstitutionUrl=https://cioospacific.ca/
 ERDDAP_adminIndividualName=Name
 ERDDAP_adminPosition=Position
 ERDDAP_adminPhone=555-555-5555
@@ -43,3 +43,4 @@ ERDDAP_MAX_MEMORY=2G
 
 # ERDDAP Secrets
 # ERDDAP_SECRET_(.*)=secret
+


### PR DESCRIPTION
When copying sample.env into .env, the server wouldn't start up due to the below error.

```
erddap    | ERROR while reading /usr/local/tomcat/content/erddap/setup.xml:
erddap    | java.lang.RuntimeException: setup.xml error: invalid <adminInstitutionUrl>=www.instituteion-url.com
```

By replacing the URL, its possible to spin up the docker container by just copying over `sample.env` to `.env` allowing for faster dev bring up and lowering debugging and troubleshooting. 